### PR TITLE
Updated build.gradle files

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
+    compileSdkVersion 26
 
     defaultConfig {
         applicationId "com.amazonaws.devicefarm.android.referenceapp"
         minSdkVersion 14
-        targetSdkVersion 25
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -32,6 +32,8 @@ android {
 
 repositories {
     mavenCentral()
+    google()
+    jcenter()
 }
 
 dependencies {
@@ -39,10 +41,10 @@ dependencies {
     implementation 'com.jakewharton:butterknife:8.8.1'
     annotationProcessor 'com.jakewharton:butterknife-compiler:8.8.1'
     implementation 'com.google.code.gson:gson:2.8.0'
-    implementation 'com.android.support:cardview-v7:25.3.0'
-    implementation 'com.android.support:appcompat-v7:25.3.0'
-    implementation 'com.android.support:recyclerview-v7:25.3.0'
-    implementation 'com.android.support:support-v4:25.3.0'
+    implementation 'com.android.support:cardview-v7:26.1.0'
+    implementation 'com.android.support:appcompat-v7:26.1.0'
+    implementation 'com.android.support:recyclerview-v7:26.1.0'
+    implementation 'com.android.support:support-v4:26.1.0'
     implementation 'com.google.android.gms:play-services-location:11.0.4'
     implementation 'com.squareup.picasso:picasso:2.5.2'
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,10 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:4.0.1'
     }
+}
+
+repositories {
+    google()
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Jun 18 08:56:11 UTC 2018
+#Fri Oct 09 10:47:30 BST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip


### PR DESCRIPTION
Version of gradle has been upgraded and the API level has been upped from 25 to 26 as it is required for the Google Play Services. 
Libraries that were targetting API 25 have also been updated to 26.

Note the lab instructions suggest a Nexus 5 running API level 25, they will probably need API level 26 instead.